### PR TITLE
Simplify CSV download logic

### DIFF
--- a/src/components/AttendanceSystem.jsx
+++ b/src/components/AttendanceSystem.jsx
@@ -117,58 +117,26 @@ const AttendanceSystem = () => {
   };
 
   const downloadCSV = () => {
-    if (!selectedClass) {
-      setMessage({ type: 'error', text: 'Lütfen önce bir sınıf seçin.' });
-      return;
-    }
-
     const classStudents = students[selectedClass] || [];
     const className = classes.find(c => c.id === selectedClass)?.name || selectedClass;
     const lessonCount = getLessonCount();
 
-    if (lessonCount === 0) {
-      setMessage({ type: 'error', text: 'Seçilen tarih için ders tanımlanmamış.' });
-      return;
-    }
+    let csv = `Sınıf:,${className}\nTarih:,${selectedDate}\n\n`;
+    csv += 'Öğrenci Adı,' + Array.from({ length: lessonCount }, (_, i) => `${i + 1}. Ders`).join(',') + '\n';
 
-    if (classStudents.length === 0) {
-      setMessage({ type: 'warning', text: 'Bu sınıfa kayıtlı öğrenci bulunmuyor.' });
-      return;
-    }
-
-    const escapeCell = (value) => `"${String(value).replace(/"/g, '""')}"`;
-
-    const headerRows = [
-      [escapeCell('Sınıf:'), escapeCell(className)],
-      [escapeCell('Tarih:'), escapeCell(selectedDate)],
-      []
-    ];
-
-    const lessonsHeader = ['Öğrenci Adı', ...Array.from({ length: lessonCount }, (_, i) => `${i + 1}. Ders`)];
-    const studentRows = classStudents.map((student) => {
-      const statuses = Array.from({ length: lessonCount }, (_, i) => attendance[`${student.id}-${i + 1}`] || '-');
-      return [student.name, ...statuses];
+    classStudents.forEach(student => {
+      const row = [student.name];
+      for (let i = 1; i <= lessonCount; i++) {
+        row.push(attendance[`${student.id}-${i}`] || '-');
+      }
+      csv += row.join(',') + '\n';
     });
 
-    const csv = [
-      ...headerRows,
-      lessonsHeader.map(escapeCell),
-      ...studentRows.map((row) => row.map(escapeCell))
-    ]
-      .map((row) => row.join(','))
-      .join('\n');
-
     const blob = new Blob(['\ufeff' + csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
-    link.href = url;
-    link.setAttribute('download', `Yoklama_${className.replace(/\s+/g, '-')}_${selectedDate}.csv`);
-    document.body.appendChild(link);
+    link.href = URL.createObjectURL(blob);
+    link.download = `Yoklama_${className}_${selectedDate}.csv`;
     link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-
-    setMessage({ type: 'success', text: 'Yoklama dosyanız indirildi.' });
   };
 
   const getAbsenceLimit = (classId) => {


### PR DESCRIPTION
## Summary
- revert the CSV export routine to the previously working implementation used in production
- remove extra validation and DOM manipulation around the CSV download link to match the deployed version

## Testing
- ⚠️ `npm install` *(fails: registry access returns 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf70c3a04832b843f8840f057cb75